### PR TITLE
修正表单的验证码按钮样式

### DIFF
--- a/src/style/widget/weui-cell/weui-form/_weui-vcode.scss
+++ b/src/style/widget/weui-cell/weui-form/_weui-vcode.scss
@@ -21,14 +21,15 @@
     vertical-align: middle;
     font-size: $weuiCellFontSize;
     color: $weuiDialogLinkColor;
-    button & {
-        background-color: transparent;
-        border-top: 0;
-        border-right: 0;
-        border-bottom: 0;
-        outline: 0;
-    }
     &:active {
         color: desaturate($weuiDialogLinkColor, 30%);
     }
+}
+
+button.#{$weui_ns}vcode-btn {
+    background-color: transparent;
+    border-top: 0;
+    border-right: 0;
+    border-bottom: 0;
+    outline: 0;
 }


### PR DESCRIPTION
官方页面 ( https://weui.io/#input ) 中, 获取验证码按钮的样式定义如下:

```less
.weui-vcode-btn {
    display: inline-block;
    height: @weuiCellHeight;
    margin-left: 5px;
    padding: 0 0.6em 0 0.7em;
    border-left: 1px solid @weuiLineColorLight;
    line-height: @weuiCellHeight;
    vertical-align: middle;
    font-size: @weuiCellFontSize;
    color: @weuiDialogLinkColor;
    button&{
        background-color: transparent;
        border-top: 0;
        border-right: 0;
        border-bottom: 0;
        outline: 0;
    }
    &:active {
        color: desaturate(@weuiDialogLinkColor, 30%);
    }
}
```

`<button class="weui-vcode-btn">获取验证码</button>` 的显示效果正常.

Gem 目前生成的 css, 必须要求 `.weui-vcode-btn` 是 `button` 的子元素. 所以按官方的写法就会导致显示不正常.

